### PR TITLE
Library crashes on managerevent, datablock[evt.actionid] not initialized

### DIFF
--- a/asterisk.js
+++ b/asterisk.js
@@ -262,6 +262,7 @@ var Manager = function(port, host) {
 	this.on('managerevent', function(evt){
 		//console.log(evt);
 		var EOR = ['queuestatuscomplete','queuesummarycomplete','dahdishowchannelscomplete','peerlistcomplete','dbgetresponse']
+		datablock[evt.actionid] = [];
 		datablock[evt.actionid].push(evt);
 		if(EOR.indexOf(evt.event) > -1  /*evt.event == funcblock[evt.actionid].EOR*/){
 			if (timeoutProtect[evt.actionid]){


### PR DESCRIPTION
Previously, a crash would occur on a managerevent being emitted, due to the lack of initialization of datablock[evt.actionid] before pushing onto it. In this pull request, datablock[evt.actionid] is initialized to an empty array first, and events come through fine.
