### PR TITLE
Fix a couple of minor issues

### DIFF
--- a/lib/ami.js
+++ b/lib/ami.js
@@ -16,6 +16,7 @@ var Manager = function Manager(port, host, username, password, events) {
   var obj={};
   var context = {};
   context.emitter = new EventEmitter();
+  context.held = [];
 
   Object.defineProperty(obj, 'on', { value:context.emitter.on.bind(context.emitter) });
   Object.defineProperty(obj, 'once', { value:context.emitter.once.bind(context.emitter) });


### PR DESCRIPTION
Manager can't be exported until it is defined, and context.held needs to be initialized.

This fixes the issues I had with getting asterisk-manager to work out of the box:

TypeError: undefined is not a function
TypeError: Cannot call method 'forEach' of undefined
