### PR TITLE
Adding repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,5 +4,9 @@
   "version": "0.1.7",
   "description": "A node.js module for interacting with the Asterisk Manager API.",
   "keywords": ["asterisk", "voip"],
-  "main": "index.js"
+  "main": "index.js",
+  "repository" : {
+    "type" : "git",
+    "url" : "https://github.com/pipobscure/NodeJS-AsteriskManager.git"
+  }
 }


### PR DESCRIPTION
```
The field is used for informational purposes.
Read more about the repository¹ field, and see the logged² bug for further details.
```

– http://stackoverflow.com/a/16827990/1129927
1. https://npmjs.org/doc/json.html#repository
2. https://github.com/isaacs/npm/issues/3568
