### PR TITLE
Handling duplicate keys

### DIFF
--- a/lib/ami.js
+++ b/lib/ami.js
@@ -140,7 +140,25 @@ function ManagerReader(context, data) {
         line = line.split(':');
         var key = Utils.removeSpaces(line.shift()).toLowerCase();
         line = Utils.removeSpaces(line.join(':'));
-        item[key] = line;
+        if (key === 'variable') {
+          // Handle special case of one or more variables attached to an event and
+          // create a variables subobject in the event object
+          if (typeof(item[key]) !== 'object')
+            item[key] = {};
+          line = line.split('=');
+          var subkey = line.shift().toLowerCase();
+          item[key][subkey] = line.join('=');
+        } else {
+          // Generic case of multiple copies of a key in an event.
+          // Create an array of values.
+          if (key in item) {
+            if (Array.isArray(item[key]))
+              item[key].push(line);
+            else
+              item[key] = [item[key]];
+          } else
+            item[key] = line;
+        }
       }
       context.follow = false;
       lines = [];


### PR DESCRIPTION
Added handing of duplicate keys in a single response.  There is the
generic case of simple keys appearing more than once and the special
case where events returned contain one or more channel variables, e.g.
AgentConnect with setqueuevar=yes.