### PR TITLE
Restore 'managerevent' and event handlers

### DIFF
--- a/lib/ami.js
+++ b/lib/ami.js
@@ -164,7 +164,9 @@ function ManagerEvent(context, event) {
     // This is a follows response
     emits.push(this.emit.bind(this, context.lastid, undefined, event));
     emits.push(this.emit.bind(this, 'response', event));
-  } else if (event.event) {
+  }
+  
+  if (event.event) {
     // This is a Real-Event
     emits.push(this.emit.bind(this, 'managerevent', event));
     emits.push(this.emit.bind(this, event.event.toLowerCase(), event));


### PR DESCRIPTION
Responses for an Action shoudl also emit 'managerevent' and event.

According to: https://github.com/pipobscure/NodeJS-AsteriskManager/issues/25