### PR TITLE
Pass all responses to ami.action's callback

### DIFF
--- a/lib/ami.js
+++ b/lib/ami.js
@@ -298,7 +298,7 @@ function ManagerAction(context, action, callback) {
     return id;
   }
 
-  this.once(id, callback);
+  this.on(id, callback);
   return context.lastid = id;
 }
 


### PR DESCRIPTION
Example:

    ami.action({
      'action':'originate',
      'channel':'sip/zadarma/<phone>',
      'context':'audio-captcha',
      'exten':'play',
      'priority':1,
      'async': 'true',
      'actionid': _id,
      'variable':{
        'CAPTCHA': '199',
        'lang': 'en'
      }
    }, function(err, res) {
        if(err)
            console.log(err);
    
        console.log(res);
    });

will call callback twice:
    
    { response: 'Success',
      actionid: '452c5b53-6a99-4456-b3e5-c0079bfeb059',
      message: 'Originate successfully queued' }
    { event: 'OriginateResponse',
      privilege: 'call,all',
      actionid: '452c5b53-6a99-4456-b3e5-c0079bfeb059',
      response: 'Success',
      channel: 'SIP/zadarma-00000009',
      context: 'audio-captcha',
      exten: 'play',
      reason: '4',
      uniqueid: '1421969050.9',
      calleridnum: '<unknown>',
      calleridname: '<unknown>' }

According to: https://github.com/pipobscure/NodeJS-AsteriskManager/issues/25