### PR TITLE
allow channel vars in events

### DIFF
--- a/lib/ami.js
+++ b/lib/ami.js
@@ -140,7 +140,7 @@ function ManagerReader(context, data) {
         line = line.split(':');
         var key = Utils.removeSpaces(line.shift()).toLowerCase();
         line = Utils.removeSpaces(line.join(':'));
-        if (key === 'variable') {
+        if (key === 'variable' || key === 'chanvariable') {
           // Handle special case of one or more variables attached to an event and
           // create a variables subobject in the event object
           if (typeof(item[key]) !== 'object')


### PR DESCRIPTION
I'm using this module to catch AMI events and I noticed that from all the variables that I set in the channel, only one appears in the event data.
After I debugged the code I realised that asterisk sends channel vars in key called "chanvariable".