### PR TITLE
Set correct case on Asterisk variables

### DIFF
--- a/lib/ami.js
+++ b/lib/ami.js
@@ -149,7 +149,7 @@ function ManagerReader(context, data) {
           if (typeof(item[key]) !== 'object')
             item[key] = {};
           line = line.split('=');
-          var subkey = line.shift().toLowerCase();
+          var subkey = line.shift();
           item[key][subkey] = line.join('=');
         } else {
           // Generic case of multiple copies of a key in an event.


### PR DESCRIPTION
After much hair pulling I've realized that NodeJS-AsteriskManager toLowerCases everything which is fine except when it comes to variable and channel variable names. This is because Asterisk itself is case insensitive when it comes to this.

Thus two valid variables can be:

- thisismyvariable=1
- thisISMYVARIABLE=2

In the dialplan (and also in ARI) the variables are both separate and can be called separately. However in NodeJS-AsteriskManager the event for variables and chanvariables the variable name is always toLowerCase. Thus the result of see variables or chanvariables through an event would always mean the second event of 'thisISMYVARIABLE' would end up being identical to 'thisismyvariable'.

This PR fixes that issue but not setting toLowerCase but only if its a variable or chanvariable

This could potentially affect previously users of this library but if that is the case then they are/were working around a previous bug because Asterisk would infact log and carry both variables and when you ask Asterisk (or by proxy Asterisk's ARI) for the correct case you'd get the correct value back