### PR TITLE
Bugfix in ManagerEvent function.

### DIFF
--- a/lib/ami.js
+++ b/lib/ami.js
@@ -175,7 +175,7 @@ function ManagerReader(context, data) {
 
 function ManagerEvent(context, event) {
   var emits = [];
-  if (event.response && event.actionid) {
+  if (event.response && event.actionid && typeof event.response == "string") {
     // This is the response to an Action
     emits.push(this.emit.bind(this, event.actionid, (event.response.toLowerCase() == 'error') ? event : undefined, event));
     emits.push(this.emit.bind(this, 'response', event));


### PR DESCRIPTION
At times when the queue grows too large, the 'event.response' parameter at line 180 of the 'ami.js' file receives a string vector instead of a string. This causes the module to be aborted at the time of the '**event.response.toLowerCase ()**'. The fix ensures that always a string in the 'event.response' and avoids the error: '**TypeError: event.response.toLowerCase is not a function**', where: _event.response = ["Success", "Success"]_

After correction, if '**event.response**' receives a string vector, it is ignored, not affecting module operation.