### PR TITLE
Fix AMI Re-connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Asterisk Manager API [![Total views](https://sourcegraph.com/api/repos/github.com/pipobscure/NodeJS-AsteriskManager/.counters/views.png)](https://sourcegraph.com/github.com/pipobscure/NodeJS-AsteriskManager)
-[![NPM](https://nodei.co/npm/asterisk-manager.png)](https://nodei.co/npm/asterisk-manager/)  
+# Asterisk Manager API
 
 For a project of mine I needed a low level interface to the Asterisk Manager API. I looked around and found https://github.com/mscdex/node-asterisk . While it was a good starting point, it had too many abstractions for my taste. Which is why I based my version on it an then radically refactored it. In the end there now is very little in common with it.
 

--- a/lib/ami.js
+++ b/lib/ami.js
@@ -17,7 +17,7 @@ var Utils = require('./utils');
 var Manager = function Manager(port, host, username, password, events) {
 
   var obj = {};
-  var context = { backoff: 10 };
+  var context = { backoff: 10000 };
   var properties = ['on', 'once', 'addListener', 'removeListener', 'removeAllListeners',
                     'listeners', 'setMaxListeners', 'emit'];
 
@@ -236,11 +236,15 @@ function ManagerKeepConnected(context) {
 }
 function ManagerReconnect(context) {
     var connect = this.connect.bind(this.options.port, this.options.host, this.login.bind(this));
-    setTimeout(connect, context.backoff);
-    context.backoff *= context.backoff;
+  console.log('Trying to reconnect to AMI in '+ (context.backoff / 1000) +' seconds');
+
+  setTimeout(connect, context.backoff);
+  if(context.backoff < 60000){ //The maximum reconection time is 60 seconds
+    context.backoff += 10000; //Increase reconnection time by 10 seconds
+  }
 }
 function ManagerResetBackoff(context) {
-    context.backoff = 10;
+    context.backoff = 10000;
 }
 
 function MakeManagerAction(req, id) {

--- a/lib/ami.js
+++ b/lib/ami.js
@@ -235,9 +235,9 @@ function ManagerKeepConnected(context) {
   }
 }
 function ManagerReconnect(context) {
-    var connect = this.connect.bind(this.options.port, this.options.host, this.login.bind(this));
   console.log('Trying to reconnect to AMI in '+ (context.backoff / 1000) +' seconds');
 
+  var connect = this.connect.bind(context, this.options.port, this.options.host, this.login.bind(this));
   setTimeout(connect, context.backoff);
   if(context.backoff < 60000){ //The maximum reconection time is 60 seconds
     context.backoff += 10000; //Increase reconnection time by 10 seconds


### PR DESCRIPTION
The current implementation is not able to reconnect to Asterisk AMI per two reasons:

- There's a missed parameter when connect function is called
- The re-connection time in the fourth try is increased to almost 1 day, is too much time to wait for re-connection, so, in this commits the maximum re-connection time has been set to 60 seconds.