### PR TITLE
added case-insensitive ActionID support

### DIFF
--- a/lib/ami.js
+++ b/lib/ami.js
@@ -294,13 +294,16 @@ function ManagerAction(context, action, callback) {
   action = action || {};
   callback = Utils.defaultCallback(callback);
 
-  var id = action.actionid || String((new Date()).getTime());
+  var id = String((new Date()).getTime());
+  // find case insensitive occurence of property 'actionid' (e.g. 'ActionID' could have been set)
+  var idMatch = Object.keys(action).join().match(/(.+,)?(actionid)(,.+)?/i);
+  if (idMatch != null) {
+    id = action[idMatch[2]];
+    delete action[idMatch[2]];
+  }
 
   while (this.listeners(id).length)
     id += String(Math.floor(Math.random() * 9));
-
-  if (action.actionid)
-    delete action.actionid;
 
   if (!context.authenticated && (action.action !== 'login')) {
     context.held = context.held || [];


### PR DESCRIPTION
This also allows the use of the action id property in the notation 'ActionID' described by the AMI specification.
Up to now, only a property named 'actionid' is checked. If this is not present, a UNIX timestamp is generated, although the 'ActionID' was set in the request.
The fix allows all possible upper/lower case variants of this property.