### PR TITLE
support for 'autherror' event

### DIFF
--- a/lib/ami.js
+++ b/lib/ami.js
@@ -211,7 +211,10 @@ function ManagerLogin(context, callback) {
     'secret': options.password,
     'event': options.events ? 'on' : 'off'
   }, (function(err) {
-    if (err) return callback(err);
+    if (err) {
+      process.nextTick(this.emit.bind(this, 'autherror', new Error(err.message)));
+      return callback(err);
+    }
 
     process.nextTick(callback.bind(this));
     context.authenticated = true;


### PR DESCRIPTION
This adds support for a new 'autherror' event. It will be triggered as soon as the authentication to the AMI using the Login action fails.

Motivation: If the connection to the AMI is closed, it is not necessarily clear that it is due to a failed authentication. This can currently only be determined via the action response in a 'response' event. However, it is not obvious to listen for this event to notice the authentication failure and it's not an efficient / reliable solution to check all AMI responses for a specific error message.